### PR TITLE
fix aname buffers in s9proc

### DIFF
--- a/c9.c
+++ b/c9.c
@@ -1121,7 +1121,7 @@ s9proc(C9ctx *c)
 		if(cnt > sz)
 			goto error;
 		memmove(b-1, b, cnt);
-		t.attach.aname = (char*)b;
+		t.attach.aname = (char*)b-1;
 		t.attach.aname[cnt] = 0;
 		c->t(c, &t);
 		break;
@@ -1142,7 +1142,7 @@ s9proc(C9ctx *c)
 		if(cnt > sz)
 			goto error;
 		memmove(b-1, b, cnt);
-		t.auth.aname = (char*)b;
+		t.auth.aname = (char*)b-1;
 		t.auth.aname[cnt] = 0;
 		c->t(c, &t);
 		break;


### PR DESCRIPTION
Memory checker founds that a zero writing to the last byte of t.auth.aname pointer would corrupt the memory. Also I am missing the first character of the aname. So the solution will fix these two problems.